### PR TITLE
fix: large screen expands to maxWidth 800

### DIFF
--- a/lib/src/view/screen/home_screen.dart
+++ b/lib/src/view/screen/home_screen.dart
@@ -1,3 +1,4 @@
+import 'package:e_commerce_flutter/src/view/widget/page_wrapper.dart';
 import 'package:flutter/material.dart';
 import 'package:animations/animations.dart';
 import 'package:bottom_navy_bar/bottom_navy_bar.dart';
@@ -26,39 +27,41 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      bottomNavigationBar: BottomNavyBar(
-        itemCornerRadius: 10,
-        selectedIndex: newIndex,
-        items: AppData.bottomNavyBarItems
-            .map(
-              (item) => BottomNavyBarItem(
-                icon: item.icon,
-                title: Text(item.title),
-                activeColor: item.activeColor,
-                inactiveColor: item.inActiveColor,
-              ),
-            )
-            .toList(),
-        onItemSelected: (currentIndex) {
-          newIndex = currentIndex;
-          setState(() {});
-        },
-      ),
-      body: PageTransitionSwitcher(
-        duration: const Duration(seconds: 1),
-        transitionBuilder: (
-          Widget child,
-          Animation<double> animation,
-          Animation<double> secondaryAnimation,
-        ) {
-          return FadeThroughTransition(
-            animation: animation,
-            secondaryAnimation: secondaryAnimation,
-            child: child,
-          );
-        },
-        child: HomeScreen.screens[newIndex],
+    return PageWrapper(
+      child: Scaffold(
+        bottomNavigationBar: BottomNavyBar(
+          itemCornerRadius: 10,
+          selectedIndex: newIndex,
+          items: AppData.bottomNavyBarItems
+              .map(
+                (item) => BottomNavyBarItem(
+                  icon: item.icon,
+                  title: Text(item.title),
+                  activeColor: item.activeColor,
+                  inactiveColor: item.inActiveColor,
+                ),
+              )
+              .toList(),
+          onItemSelected: (currentIndex) {
+            newIndex = currentIndex;
+            setState(() {});
+          },
+        ),
+        body: PageTransitionSwitcher(
+          duration: const Duration(seconds: 1),
+          transitionBuilder: (
+            Widget child,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+          ) {
+            return FadeThroughTransition(
+              animation: animation,
+              secondaryAnimation: secondaryAnimation,
+              child: child,
+            );
+          },
+          child: HomeScreen.screens[newIndex],
+        ),
       ),
     );
   }

--- a/lib/src/view/screen/product_detail_screen.dart
+++ b/lib/src/view/screen/product_detail_screen.dart
@@ -1,3 +1,4 @@
+import 'package:e_commerce_flutter/src/view/widget/page_wrapper.dart';
 import 'package:get/get.dart';
 import 'package:flutter/material.dart';
 import 'package:e_commerce_flutter/core/app_color.dart';
@@ -103,80 +104,82 @@ class ProductDetailScreen extends StatelessWidget {
         extendBodyBehindAppBar: true,
         appBar: _appBar(context),
         body: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              productPageView(width, height),
-              const SizedBox(height: 20),
-              Padding(
-                padding: const EdgeInsets.all(20),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      product.name,
-                      style: Theme.of(context).textTheme.displayMedium,
-                    ),
-                    const SizedBox(height: 10),
-                    _ratingBar(context),
-                    const SizedBox(height: 10),
-                    Row(
-                      children: [
-                        Text(
-                          product.off != null
-                              ? "\$${product.off}"
-                              : "\$${product.price}",
-                          style: Theme.of(context).textTheme.displayLarge,
-                        ),
-                        const SizedBox(width: 3),
-                        Visibility(
-                          visible: product.off != null ? true : false,
-                          child: Text(
-                            "\$${product.price}",
-                            style: const TextStyle(
-                              decoration: TextDecoration.lineThrough,
-                              color: Colors.grey,
-                              fontWeight: FontWeight.w500,
+          child: PageWrapper(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                productPageView(width, height),
+                const SizedBox(height: 20),
+                Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        product.name,
+                        style: Theme.of(context).textTheme.displayMedium,
+                      ),
+                      const SizedBox(height: 10),
+                      _ratingBar(context),
+                      const SizedBox(height: 10),
+                      Row(
+                        children: [
+                          Text(
+                            product.off != null
+                                ? "\$${product.off}"
+                                : "\$${product.price}",
+                            style: Theme.of(context).textTheme.displayLarge,
+                          ),
+                          const SizedBox(width: 3),
+                          Visibility(
+                            visible: product.off != null ? true : false,
+                            child: Text(
+                              "\$${product.price}",
+                              style: const TextStyle(
+                                decoration: TextDecoration.lineThrough,
+                                color: Colors.grey,
+                                fontWeight: FontWeight.w500,
+                              ),
                             ),
                           ),
+                          const Spacer(),
+                          Text(
+                            product.isAvailable
+                                ? "Available in stock"
+                                : "Not available",
+                            style: const TextStyle(fontWeight: FontWeight.w500),
+                          )
+                        ],
+                      ),
+                      const SizedBox(height: 30),
+                      Text(
+                        "About",
+                        style: Theme.of(context).textTheme.headlineMedium,
+                      ),
+                      const SizedBox(height: 10),
+                      Text(product.about),
+                      const SizedBox(height: 20),
+                      SizedBox(
+                        height: 40,
+                        child: GetBuilder<ProductController>(
+                          builder: (_) => productSizesListView(),
                         ),
-                        const Spacer(),
-                        Text(
-                          product.isAvailable
-                              ? "Available in stock"
-                              : "Not available",
-                          style: const TextStyle(fontWeight: FontWeight.w500),
-                        )
-                      ],
-                    ),
-                    const SizedBox(height: 30),
-                    Text(
-                      "About",
-                      style: Theme.of(context).textTheme.headlineMedium,
-                    ),
-                    const SizedBox(height: 10),
-                    Text(product.about),
-                    const SizedBox(height: 20),
-                    SizedBox(
-                      height: 40,
-                      child: GetBuilder<ProductController>(
-                        builder: (_) => productSizesListView(),
                       ),
-                    ),
-                    const SizedBox(height: 20),
-                    SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton(
-                        onPressed: product.isAvailable
-                            ? () => controller.addToCart(product)
-                            : null,
-                        child: const Text("Add to cart"),
-                      ),
-                    )
-                  ],
-                ),
-              )
-            ],
+                      const SizedBox(height: 20),
+                      SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: product.isAvailable
+                              ? () => controller.addToCart(product)
+                              : null,
+                          child: const Text("Add to cart"),
+                        ),
+                      )
+                    ],
+                  ),
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/view/widget/page_wrapper.dart
+++ b/lib/src/view/widget/page_wrapper.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class PageWrapper extends StatelessWidget {
+  final Widget child;
+  const PageWrapper({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800), child: child),
+    );
+  }
+}


### PR DESCRIPTION
Hi ,, 

great app, good job .. 

noticed that when screen expands to higher width, the app appearance break ..

 
![Screenshot 2023-03-02 210155](https://user-images.githubusercontent.com/67714308/222523244-79dcb13d-1d8f-4095-8e85-c68fb1d039b9.png)

![Screenshot 2023-03-02 210223](https://user-images.githubusercontent.com/67714308/222523320-76bc2958-c3aa-43df-a38d-c61534e61116.png)

I though of adding a page wrapper widget that sets the maxWidth for page to 800, and wrap it with the main page .. 
this is how the end result looks on larger screens ... 

![Screenshot 2023-03-02 213318](https://user-images.githubusercontent.com/67714308/222523461-46e5f87b-a644-4cac-a058-dfee92755bbf.png)
![Screenshot 2023-03-02 210310](https://user-images.githubusercontent.com/67714308/222523488-4fd3e88e-26c0-49fc-9361-650f8f6a8407.png)
![Screenshot 2023-03-02 213819](https://user-images.githubusercontent.com/67714308/222523519-e3bfb7b9-c52a-4e16-974a-a137e093a716.png)

If you need any refactoring , reach out to me .. 
thanks .. 



